### PR TITLE
Temporarily remove the olm library and crypto support in matrix

### DIFF
--- a/lib/devices/builtins/matrix/index.js
+++ b/lib/devices/builtins/matrix/index.js
@@ -9,7 +9,7 @@
 // See COPYING for details
 "use strict";
 
-global.Olm = require('olm');
+//global.Olm = require('olm');
 const Tp = require('thingpedia');
 const Matrix = require("matrix-js-sdk");
 
@@ -86,7 +86,8 @@ async function makeMatrixClient(userId, deviceId, platform, storage, accessToken
         deviceId: deviceId,
         accessToken: accessToken
     });
-    matrixClient.initCrypto();
+    if (global.Olm)
+        matrixClient.initCrypto();
     return matrixClient;
 }
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "deep-equal": "^1.0.1",
     "ip": "^1.1.5",
     "matrix-js-sdk": "0.9.2",
-    "olm": "https://matrix.org/packages/npm/olm/olm-2.2.2.tgz",
     "q": "^1.5.0",
     "sqlite3": "^4.0.2",
     "thingpedia": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,10 +1536,6 @@ object-assign@^4.1.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-"olm@https://matrix.org/packages/npm/olm/olm-2.2.2.tgz":
-  version "2.2.2"
-  resolved "https://matrix.org/packages/npm/olm/olm-2.2.2.tgz#7e217d862ab0fd189565e0aea3337efda2dadce4"
-
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"


### PR DESCRIPTION
The olm library is no longer available for download after today's
attacks on matrix.org infrastructure.

To restore tests and building, remove the feature until we find
a replacement.