### PR TITLE
Add a builtin function for the easter eggs/canned replies

### DIFF
--- a/data/thingengine.builtin.tt
+++ b/data/thingengine.builtin.tt
@@ -29,6 +29,13 @@ class @org.thingpedia.builtin.thingengine.builtin {
   #_[formatted=[{type="text",text="${program}"}]]
   #[doc="retrieve the list of supported commands for the given device"];
 
+  query canned_reply(in req intent: Enum(hello,cool,sorry,thank_you),
+                   out text : String)
+  #_[canonical="get canned reply"]
+  #_[confirmation="a reply to ${intent}"]
+  #_[formatted=["${text}"]]
+  #[doc="provide a canned reply to some common intents"];
+
   action debug_log(in req message: String #_[prompt="What should I write in the logs?"])
   #_[canonical="log"]
   #_[confirmation="write $message in the developer logs"]

--- a/lib/devices/builtins/thingengine.builtin.js
+++ b/lib/devices/builtins/thingengine.builtin.js
@@ -12,6 +12,15 @@
 const Tp = require('thingpedia');
 const TT = require('thingtalk');
 
+function N_(x) { return x; }
+
+const CANNED_RESPONSES = {
+    hello: N_("Hi!"),
+    cool: N_("I know, right?"),
+    sorry: N_("No need to be sorry."),
+    thank_you: N_("At your service.")
+};
+
 // A placeholder object for builtin triggers/queries/actions that
 // don't have any better place to live, such as those related to
 // time
@@ -42,6 +51,9 @@ module.exports = class MiscellaneousDevice extends Tp.BaseDevice {
     }
     get_get_random_between({ low, high }) {
         return [{ random: Math.round(low + (Math.random() * (high - low))) }];
+    }
+    get_canned_reply({ intent }) {
+        return [{ text: this.engine._(CANNED_RESPONSES[intent]) }];
     }
 
     async get_get_commands({ device }) {

--- a/test/test_builtins.js
+++ b/test/test_builtins.js
@@ -43,6 +43,9 @@ async function testOtherBuiltins(engine) {
     assert(random.random >= 0);
     assert(random.random <= 7);
     assert.strictEqual(Math.floor(random.random), random.random);
+
+    const [hello] = await device.get_canned_reply({ intent: 'hello' });
+    assert.deepStrictEqual(hello, { text: "Hi!" });
 }
 
 function testBuiltinsAreExpected(engine) {


### PR DESCRIPTION
It is easier to update and requires less messing around with
newer versions of the library.

This is the first step towards cleaning up the special/bookkeeping stuff.