### PR TITLE
appdatabase, devicedatabase: update the list of exported methods

### DIFF
--- a/lib/apps/database.js
+++ b/lib/apps/database.js
@@ -218,4 +218,4 @@ module.exports = class AppDatabase extends events.EventEmitter {
         return this._apps[id] !== undefined;
     }
 };
-module.exports.prototype.$rpcMethods = ['loadOneApp', 'removeApp', 'getAllApps', 'getApp', 'hasApp'];
+module.exports.prototype.$rpcMethods = ['loadOneApp', 'createApp', 'removeApp', 'getAllApps', 'getApp', 'hasApp'];

--- a/lib/devices/database.js
+++ b/lib/devices/database.js
@@ -348,6 +348,10 @@ module.exports = class DeviceDatabase extends ObjectSet.Base {
     }
 };
 module.exports.prototype.$rpcMethods = ['loadOneDevice', 'getAllDevices', 'getAllDevicesOfKind',
-                                        'hasDevice',
-                                        'getDevice', 'removeDevice', 'get factory', 'get schemas',
-                                        'reloadDevice', 'updateDevicesOfKind'];
+                                        'hasDevice', 'getDevice',
+                                        'removeDevice',
+                                        'addSerialized', 'addFromOAuth', 'completeOAuth',
+                                        'addFromDiscovery', 'completeDiscovery', 'addInteractively',
+                                        'get factory',
+                                        'reloadDevice',
+                                        'updateDevicesOfKind'];


### PR DESCRIPTION
almond-cloud cannot make use of the new high-level APIs without
some significant amounts of surgery, so make sure it can keep using
the apps/devices modules instead