### PR TITLE
Add #[confirm] annotations to all builtin functions

### DIFF
--- a/data/test.tt
+++ b/data/test.tt
@@ -14,24 +14,28 @@ class @org.thingpedia.builtin.test
   #_[confirmation_remote="generate $size of fake data on $__person's Almond"]
   #_[formatted=[{type="text",text="${data}"}]]
   #[poll_interval=0ms]
-  #[doc="generate `size` amount of fake data"];
+  #[doc="generate `size` amount of fake data"]
+  #[confirm=false];
 
   query next_sequence(out number: Number)
   #_[canonical="get sequence number on test"]
   #_[confirmation="return the next test number"]
   #_[formatted=[{type="text",text="${number}"}]]
-  #[doc="return the next number in a global sequence; used to test that the queries are invoked the correct number of times; this query is an abuse (it has side effects!), don't copy it in your own devices"];
+  #[doc="return the next number in a global sequence; used to test that the queries are invoked the correct number of times; this query is an abuse (it has side effects!), don't copy it in your own devices"]
+  #[confirm=false];
 
   query dup_data(in req data_in: String #_[prompt="What data do you want to duplicate?"],
                  out data_out: String)
   #_[canonical="duplicate data on test"]
   #_[confirmation="duplicate ${data_in} data"]
   #_[formatted=[{type="text",text="${data_out}"}]]
-  #[doc="duplicate the data (concatenate two copies); this is a simple deterministic get that depends on the input and is used to test param passing into a get"];
+  #[doc="duplicate the data (concatenate two copies); this is a simple deterministic get that depends on the input and is used to test param passing into a get"]
+  #[confirm=false];
 
   action eat_data(in req data: String #_[prompt="What do you want me to consume?"])
   #_[canonical="eat data on test"]
   #_[confirmation="consume $data"]
   #_[confirmation_remote="consume $data on $__person's Almond"]
-  #[doc="consume some data, do nothing"];
+  #[doc="consume some data, do nothing"]
+  #[confirm=true];
 }

--- a/data/thingengine.builtin.tt
+++ b/data/thingengine.builtin.tt
@@ -14,19 +14,22 @@ class @org.thingpedia.builtin.thingengine.builtin
   #_[confirmation_remote="$__person's location"]
   #_[formatted=[{type="text",text="Current Location: ${location}"}]]
   #[poll_interval=0ms]
-  #[doc="get last known GPS location"];
+  #[doc="get last known GPS location"]
+  #[confirm=false];
 
   query get_time(out time: Date)
   #_[canonical="get time"]
   #_[confirmation="the current time"]
   #_[formatted=[{type="text",text="Current time is ${time:time}."}]]
-  #[doc="get the current time; this is equivalent to $now() and exists mostly so that Sabrina can codegen it"];
+  #[doc="get the current time; this is equivalent to $now() and exists mostly so that Sabrina can codegen it"]
+  #[confirm=false];
 
   query get_date(out date: Date)
   #_[canonical="get date"]
   #_[confirmation="today's date"]
   #_[formatted=[{type="text",text="Today is ${date:date}."}]]
-  #[doc="get the current date; this is equivalent to $now() and exists mostly so that Sabrina can codegen it; also equivalent to get_time() but the default formatting is different"];
+  #[doc="get the current date; this is equivalent to $now() and exists mostly so that Sabrina can codegen it; also equivalent to get_time() but the default formatting is different"]
+  #[confirm=false];
 
   query get_random_between(in req low: Number #_[prompt="What should be the lower bound?"],
                            in req high: Number #_[prompt="What should be the upper bound?"],
@@ -34,50 +37,58 @@ class @org.thingpedia.builtin.thingengine.builtin
   #_[canonical="get random integer"]
   #_[confirmation="a random integer between $low and $high"]
   #_[formatted=[{type="text",text="${random}"}]]
-  #[doc="get a uniform random integer between `low` and `high`; this is equivalent to $random() and some rounding/mod operation"];
+  #[doc="get a uniform random integer between `low` and `high`; this is equivalent to $random() and some rounding/mod operation"]
+  #[confirm=false];
 
   list query get_commands(in req device: Entity(tt:device) #_[prompt="What device do you want help for?"],
                           out program: Entity(tt:program))
   #_[canonical="list commands"]
   #_[confirmation="the list of commands of $device"]
   #_[formatted=[{type="text",text="${program}"}]]
-  #[doc="retrieve the list of supported commands for the given device"];
+  #[doc="retrieve the list of supported commands for the given device"]
+  #[confirm=false];
 
   query canned_reply(in req intent: Enum(hello,cool,sorry,thank_you),
                    out text : String)
   #_[canonical="get canned reply"]
   #_[confirmation="a reply to ${intent}"]
   #_[formatted=["${text}"]]
-  #[doc="provide a canned reply to some common intents"];
+  #[doc="provide a canned reply to some common intents"]
+  #[confirm=false];
 
   action debug_log(in req message: String #_[prompt="What should I write in the logs?"])
   #_[canonical="log"]
   #_[confirmation="write $message in the developer logs"]
   #_[confirmation_remote="write $message in the developer logs on $__person's phone"]
-  #[doc="log a message in the developer logs"];
+  #[doc="log a message in the developer logs"]
+  #[confirm=false];
 
   action configure(in req device: Entity(tt:device) #_[prompt="What device do you want to configure?"])
   #_[canonical="configure"]
   #_[confirmation="configure a new $device"]
   #_[confirmation_remote="configure a new $device on $__person's Almond"]
-  #[doc="configure a specific device by type"];
+  #[doc="configure a specific device by type"]
+  #[confirm=false];
 
   action say(in req message: String #_[prompt="What do you want me to say?"])
   #_[canonical="say"]
   #_[confirmation="send me a message $message"]
   #_[confirmation_remote="send $__person message $message"]
-  #[doc="makes Almond say something; this is the codegennable version of @$notify"];
+  #[doc="makes Almond say something; this is the codegennable version of @$notify"]
+  #[confirm=false];
 
   action discover()
   #_[canonical="discover"]
   #_[confirmation="search for new devices"]
   #_[confirmation_remote="search for new devices on $__person's Almond"]
-  #[doc="start interactive discovery for new devices"];
+  #[doc="start interactive discovery for new devices"]
+  #[confirm=false];
 
   action open_url(in req url: Entity(tt:url) #_[prompt="What URL do you want to open?"])
   #_[canonical="open url on builtin"]
   #_[confirmation="open $url"]
   #_[confirmation_remote="open $url in $__person's PC"]
-  #[doc="open a file/link"];
+  #[doc="open a file/link"]
+  #[confirm=false];
 }
 


### PR DESCRIPTION
We must set #[confirm] to false on builtin actions to retain
pre-1.6 dialog agent behavior. Also, to be future proof set
the annotation on queries too.