### PR TITLE
matrix: recognize sync errors caused by bad access tokens

### DIFF
--- a/lib/devices/builtins/matrix/matrix_messaging.js
+++ b/lib/devices/builtins/matrix/matrix_messaging.js
@@ -242,28 +242,39 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
         return this._getFeedForRoom(this.client.getRoom(feedId), feedId);
     }
 
-    start() {
+    async start() {
         this._stopped = false;
-        return this._device.refMatrixClient().then((client) => {
-            if (this._stopped)
-                return this._device.unrefMatrixClient();
-            this.client = client;
-            this.client.startClient();
-            return Q.Promise((resolve, reject) => {
-                this.client.once('sync', (state, prev, data) => {
-                    if (state === 'PREPARED') {
-                        resolve();
-                    } else if (state === 'ERROR') {
-                        console.error('SYNC ERROR', data);
-                        reject(new Error('Sync error: ' + data.error.message));
+        const client = await this._device.refMatrixClient();
+        if (this._stopped) {
+            await this._device.unrefMatrixClient();
+            return false;
+        }
+        this.client = client;
+        this.client.startClient();
+        const ok = await new Promise((resolve, reject) => {
+            this.client.once('sync', (state, prev, data) => {
+                if (state === 'PREPARED') {
+                    resolve(true);
+                } else if (state === 'ERROR') {
+                    console.error('SYNC ERROR', data);
+
+                    // remove ourselves quietly if the error is due to an invalid (revoked) token
+                    if (data.error && data.error.errcode === 'M_UNKNOWN_TOKEN') {
+                        this._device.engine.devices.removeDevice(this._device);
+                        resolve(false);
+                        return;
                     }
-                });
-            }).then(() => {
-                this.client.on('RoomMember.membership', this._membershipListener);
-                this.client.on('Room.timeline', this._timelineListener);
-                this.client.on('Room.name', this._nameListener);
+
+                    reject(new Error('Sync error: ' + data.error.message));
+                }
             });
         });
+        if (!ok)
+            return false;
+        this.client.on('RoomMember.membership', this._membershipListener);
+        this.client.on('Room.timeline', this._timelineListener);
+        this.client.on('Room.name', this._nameListener);
+        return true;
     }
 
     stop() {

--- a/lib/devices/builtins/matrix/matrix_messaging.js
+++ b/lib/devices/builtins/matrix/matrix_messaging.js
@@ -261,6 +261,7 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
                     // remove ourselves quietly if the error is due to an invalid (revoked) token
                     if (data.error && data.error.errcode === 'M_UNKNOWN_TOKEN') {
                         this._device.engine.devices.removeDevice(this._device);
+                        this.stop();
                         resolve(false);
                         return;
                     }
@@ -282,10 +283,13 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
         if (!this.client)
             return Q();
 
-        this.client.removeListener('Room.timeline', this._timelineListener);
-        this.client.removeListener('Room.name', this._nameListener);
-        this.client.removeListener('RoomMember.membership', this._membershipListener);
-        return this.client.store._reallySave().then(() => {
+        const client = this.client;
+        this.client = null;
+
+        client.removeListener('Room.timeline', this._timelineListener);
+        client.removeListener('Room.name', this._nameListener);
+        client.removeListener('RoomMember.membership', this._membershipListener);
+        return client.store._reallySave().then(() => {
             this._device.unrefMatrixClient();
         });
     }

--- a/lib/messaging/device_manager.js
+++ b/lib/messaging/device_manager.js
@@ -275,20 +275,22 @@ module.exports = class MessagingDeviceManager extends events.EventEmitter {
         this._initMessagingIface(iface);
     }
 
-    _initMessagingIface(iface) {
-        this._messagingIfaces.push(iface);
-        return iface.start().then(() => {
-            return iface.getFeedList();
-        }).then((feeds) => {
-            iface.on('feed-added', this._feedAddedListener);
-            iface.on('feed-removed', this._feedRemovedListener);
-            iface.on('feed-changed', this._feedChangedListener);
-            iface.on('incoming-message', this._incomingMessageListener);
-            iface.on('outgoing-message', this._outgoingMessageListener);
+    async _initMessagingIface(iface) {
+        const ok = await iface.start();
+        // treat undefined as true for compat with the previous interface
+        if (ok === false)
+            return;
 
-            feeds.forEach((feedId) => {
-                this.emit('feed-added', feedId);
-            });
+        this._messagingIfaces.push(iface);
+        const feeds = await iface.getFeedList();
+        iface.on('feed-added', this._feedAddedListener);
+        iface.on('feed-removed', this._feedRemovedListener);
+        iface.on('feed-changed', this._feedChangedListener);
+        iface.on('incoming-message', this._incomingMessageListener);
+        iface.on('outgoing-message', this._outgoingMessageListener);
+
+        feeds.forEach((feedId) => {
+            this.emit('feed-added', feedId);
         });
     }
 
@@ -301,8 +303,10 @@ module.exports = class MessagingDeviceManager extends events.EventEmitter {
 
         console.log('Lost Messaging Device ' + device.uniqueId);
         const index = this._messagingIfaces.indexOf(iface);
-        if (index >= 0)
-            this._messagingIfaces.splice(index, 1);
+        if (index < 0)
+            return;
+
+        this._messagingIfaces.splice(index, 1);
 
         Promise.resolve(iface.getFeedList()).then((feeds) => {
             feeds.forEach((feedId) => {

--- a/lib/tiers/paired.js
+++ b/lib/tiers/paired.js
@@ -204,7 +204,7 @@ module.exports = class PairedEngineManager {
     }
 
     _addCloudToDB() {
-        return this._devices.loadOneDevice({
+        return this._loadDevice({
             kind: 'org.thingpedia.builtin.thingengine',
             tier: Tier.CLOUD,
             identity: '',

--- a/test/test_messaging.js
+++ b/test/test_messaging.js
@@ -209,6 +209,18 @@ async function cleanup(engine) {
         await engine.devices.removeDevice(d);
 }
 
+async function testMessagingInvalidToken(engine) {
+    await engine.devices.addSerialized({
+        kind: 'org.thingpedia.builtin.matrix',
+        identities: ['email:testuser@camembert.stanford.edu'],
+        userId: '@testuser@camembert.stanford.edu',
+        accessToken: 'invalid-access-token',
+        refreshToken: 'invalid-refresh-token',
+        deviceId: '12345678',
+        storage: {}
+    })
+}
+
 module.exports = async function testRemote(engine) {
     try {
         const messaging = engine.messaging;
@@ -224,4 +236,6 @@ module.exports = async function testRemote(engine) {
     } finally {
         await cleanup(engine);
     }
+
+    await testMessagingInvalidToken(engine);
 };

--- a/test/test_messaging.js
+++ b/test/test_messaging.js
@@ -212,13 +212,23 @@ async function cleanup(engine) {
 async function testMessagingInvalidToken(engine) {
     await engine.devices.addSerialized({
         kind: 'org.thingpedia.builtin.matrix',
-        identities: ['email:testuser@camembert.stanford.edu'],
-        userId: '@testuser@camembert.stanford.edu',
+        identities: ['email:testuserbad@camembert.stanford.edu'],
+        userId: '@testuserbad@camembert.stanford.edu',
         accessToken: 'invalid-access-token',
         refreshToken: 'invalid-refresh-token',
         deviceId: '12345678',
         storage: {}
-    })
+    });
+
+    assert(engine.devices.hasDevice('org.thingpedia.builtin.matrix-@testuserbad@camembert.stanford.edu'));
+    for (let attempts = 10; attempts >= 0; attempts--) {
+        if (!engine.devices.hasDevice('org.thingpedia.builtin.matrix-@testuserbad@camembert.stanford.edu'))
+            return;
+
+        await delay(5000);
+    }
+
+    assert.fail(`Expected the device to remove itself`);
 }
 
 module.exports = async function testRemote(engine) {


### PR DESCRIPTION
And in that case, silently remove the device. The patch requires
a bit of changes in DeviceManager to handle the case of a messaging
interface failing to initialize.

Fixes #67