### PR TITLE
DeviceDatabase: prevent recursion in updateState()

### DIFF
--- a/lib/devices/database.js
+++ b/lib/devices/database.js
@@ -32,6 +32,8 @@ module.exports = class DeviceDatabase extends ObjectSet.Base {
 
         this._subdeviceAddedListener = this._notifySubdeviceAdded.bind(this);
         this._subdeviceRemovedListener = this._notifySubdeviceRemoved.bind(this);
+
+        this._isUpdatingState = false;
     }
 
     async loadOneDevice(serializedDevice, addToDB) {
@@ -77,7 +79,9 @@ module.exports = class DeviceDatabase extends ObjectSet.Base {
     _onObjectAdded(uniqueId, row) {
         const serializedDevice = JSON.parse(row.state);
         if (uniqueId in this._devices) {
+            this._isUpdatingState = true;
             this._devices[uniqueId].updateState(serializedDevice);
+            this._isUpdatingState = false;
         } else {
             serializedDevice.uniqueId = uniqueId;
             this.loadOneDevice(serializedDevice, false);
@@ -242,11 +246,18 @@ module.exports = class DeviceDatabase extends ObjectSet.Base {
 
         if (this._devices.has(device.uniqueId)) {
             const existing = this._devices.get(device.uniqueId);
-            await existing.updateState(device.serialize());
+
+            this._isUpdatingState = true;
+            existing.updateState(device.serialize());
+            this._isUpdatingState = false;
+            await this._saveDevice(device);
             return existing;
         }
 
         device.on('state-changed', () => {
+            if (this._isUpdatingState)
+                return;
+
             this._saveDevice(device);
         });
 


### PR DESCRIPTION
When we call updateState() in DeviceDatabase, the on-disk storage
is already up to date, or going to be saved soon, so we don't want
to handle state-changed events triggered by it and save again.