### PR TITLE
DeviceView: refine devices by attribute

### DIFF
--- a/lib/devices/device_view.js
+++ b/lib/devices/device_view.js
@@ -12,6 +12,10 @@
 const Tp = require('thingpedia');
 const ObjectSet = Tp.ObjectSet;
 
+function like(str, substr) {
+    return str.toLowerCase().indexOf(substr.toLowerCase()) >= 0;
+}
+
 // A "view" of a set of devices, as a set of selectors matching
 // in specific context (which must be an ObjectSet of Devices)
 module.exports = class DeviceView extends ObjectSet.Base {
@@ -66,8 +70,15 @@ module.exports = class DeviceView extends ObjectSet.Base {
             return false;
         if (this.attrs.id)
             return device.uniqueId === this.attrs.id;
-        else
-            return true;
+
+        for (let key in this.attrs) {
+            if (key === 'id' || key === 'principal')
+                continue;
+
+            if (!like(device[key], this.attrs[key]))
+                return false;
+        }
+        return true;
     }
 
     _maybeAddSubview(device) {


### PR DESCRIPTION
Allow selecting devices according to the attributes computed by
the compiler.

Depends on https://github.com/stanford-oval/thingtalk/pull/162 to have any effect, otherwise there are no attributes other than `id` and behavior is unchanged.